### PR TITLE
Fixed display of Coupon related error messages

### DIFF
--- a/src/Model/Resolver/ApplyCoupon.php
+++ b/src/Model/Resolver/ApplyCoupon.php
@@ -89,20 +89,24 @@ class ApplyCoupon extends CartResolver
 
         $cart = $this->getCart($args);
 
-        if($cart->getItemsCount() < 1) {
+        if ($cart->getItemsCount() < 1) {
             throw new CartCouponException(__("Cart does not contain products"));
         }
 
         $cartId = $cart->getId();
         $appliedCouponCode = $this->couponManagement->get($cartId);
 
-        if($appliedCouponCode !== null){
+        if ($appliedCouponCode !== null) {
             throw new CartCouponException(
                 __('A coupon is already applied to the cart. Please remove it to apply another.')
             );
         }
 
-        $this->couponManagement->set($cartId, $couponCode);
+        try {
+            $this->couponManagement->set($cartId, $couponCode);
+        } catch (NoSuchEntityException | CouldNotSaveException $e) {
+            throw new CartCouponException(__('Coupon Code is invalid'), $e);
+        }
 
         return [];
     }

--- a/src/Model/Resolver/CartCouponException.php
+++ b/src/Model/Resolver/CartCouponException.php
@@ -7,8 +7,10 @@ namespace ScandiPWA\QuoteGraphQl\Model\Resolver;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Phrase;
 
-class CartCouponException extends LocalizedException
+class CartCouponException extends LocalizedException implements \GraphQL\Error\ClientAware
 {
+    const EXCEPTION_CATEGORY = 'cart-coupon';
+
     /**
      * Initialize object
      *
@@ -20,5 +22,20 @@ class CartCouponException extends LocalizedException
     {
         parent::__construct($phrase, $cause, $code);
     }
-}
 
+    /**
+     * @inheritdoc
+     */
+    public function isClientSafe() : bool
+    {
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getCategory() : string
+    {
+        return self::EXCEPTION_CATEGORY;
+    }
+}


### PR DESCRIPTION
Made `CouponCartException` implement `ClientAware` to return error message passed to it.
Previously magento returned "Internal Server Error", instead of actual message.

Exceptions are now caught when setting coupon code and proper error message is set.
