### PR TITLE
Added customizable options to saveCartItem endpoint

### DIFF
--- a/src/Model/Resolver/SaveCartItem.php
+++ b/src/Model/Resolver/SaveCartItem.php
@@ -43,6 +43,9 @@ use Magento\Catalog\Model\Product\Attribute\Repository;
  */
 class SaveCartItem implements ResolverInterface
 {
+    const SIMPLE_TYPE_CODE = "simple";
+    const VIRTUAL_TYPE_CODE = "virtual";
+
     /**
      * @var QuoteIdMaskFactory
      */
@@ -137,6 +140,10 @@ class SaveCartItem implements ResolverInterface
             case Type::TYPE_CODE:
                 $data = $this->setBundleRequestOptions($product, $data);
                 break;
+            case self::SIMPLE_TYPE_CODE:
+            case self::VIRTUAL_TYPE_CODE:
+                $this->setCustomizableOptions($product, $options, $data);
+                break;
         }
         
         $request = new DataObject();
@@ -182,6 +189,25 @@ class SaveCartItem implements ResolverInterface
         
         $data['bundle_option'] = $options;
         return $data;
+    }
+
+    /**
+     * @param Product $product
+     * @param array $options
+     * @param array $data
+     */
+    private function setCustomizableOptions(Product $product, array $options, array &$data): void
+    {
+        /**
+         * @TODO Validate if custom options data are correct using @var $product
+         */
+        $customizableOptions = $options['product_option']['extension_attributes']['customizable_options'] ?? [];
+        if (count($customizableOptions)) {
+            $data['options'] = [];
+            foreach ($customizableOptions as $customizableOption) {
+                $data['options'][$customizableOption['option_id']] = $customizableOption['option_value'];
+            }
+        }
     }
     
     /**

--- a/src/Model/Resolver/SaveCartItem.php
+++ b/src/Model/Resolver/SaveCartItem.php
@@ -17,6 +17,7 @@ namespace ScandiPWA\QuoteGraphQl\Model\Resolver;
 
 
 use Exception;
+use Magento\Catalog\Model\Product\Type as ProductType;
 use Magento\Framework\GraphQl\Config\Element\Field;
 use Magento\Framework\GraphQl\Exception\GraphQlInputException;
 use Magento\Framework\GraphQl\Exception\GraphQlNoSuchEntityException;
@@ -25,7 +26,6 @@ use Magento\Framework\GraphQl\Query\Resolver\Value;
 use Magento\Framework\GraphQl\Query\ResolverInterface;
 use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
 use Magento\Framework\Phrase;
-use Magento\Quote\Api\CartItemRepositoryInterface;
 use Magento\Quote\Api\CartRepositoryInterface;
 use Magento\Quote\Model\QuoteIdMaskFactory;
 use Magento\Quote\Model\ResourceModel\Quote\QuoteIdMask;
@@ -43,9 +43,6 @@ use Magento\Catalog\Model\Product\Attribute\Repository;
  */
 class SaveCartItem implements ResolverInterface
 {
-    const SIMPLE_TYPE_CODE = "simple";
-    const VIRTUAL_TYPE_CODE = "virtual";
-
     /**
      * @var QuoteIdMaskFactory
      */
@@ -140,8 +137,8 @@ class SaveCartItem implements ResolverInterface
             case Type::TYPE_CODE:
                 $data = $this->setBundleRequestOptions($product, $data);
                 break;
-            case self::SIMPLE_TYPE_CODE:
-            case self::VIRTUAL_TYPE_CODE:
+            case ProductType::TYPE_SIMPLE:
+            case ProductType::TYPE_VIRTUAL:
                 $this->setCustomizableOptions($product, $options, $data);
                 break;
         }

--- a/src/etc/schema.graphqls
+++ b/src/etc/schema.graphqls
@@ -56,11 +56,17 @@ input ProductOptionInput {
 
 input ExtensionsAttributeInput {
     configurable_item_options: [ConfigurableItemOptionsInput]
+    customizable_options: [CustomizableOptionsInput]
 }
 
 input ConfigurableItemOptionsInput {
     option_id: String
     option_value: Int
+}
+
+input CustomizableOptionsInput {
+    option_id: String!
+    option_value: String!
 }
 
 input PaymentInformation {


### PR DESCRIPTION
Fixes issue #20 - Add customizable options to saveCartItem endpoint

## Manual testing scenarios
1. Create a simple product with SKU __test-custom-options__ and at least one __required__ customizable option 
2. Make a GraphQL request with the following request body (assuming the `option_id` is `1`,  `option_value_id` is `3`, and, the `guestCartId` is `l0lKi9StPwYotTVYt124BzJKPbiJg0Cx`)
````
mutation {
  saveCartItem (
    guestCartId: "l0lKi9StPwYotTVYt124BzJKPbiJg0Cx",
    cartItem: {
      sku: "test-custom-options",
      qty: 1
      quantity: 1
      product_option: {
        extension_attributes: {
          customizable_options: [
            {
              option_id: "1",
              option_value: "3"
            }
          ]
        }
      }
    }
  ) {
    cart(cart_id: "l0lKi9StPwYotTVYt124BzJKPbiJg0Cx") {
      items {
        ...on SimpleCartItem {
          quantity
          product {
            name
            sku
          },
          customizable_options {
            label
            values {
              label
            }
          }
        }
      }
    }
  }
}
````
3. __Behaviour before PR__ Could not add custom options to cart item, resulting in product not added to cart (NO error shows)
4. __Behaviour after PR__ The product is added to the cart along with the correct custom options

## TODO
Validate if custom options data are correct (currently not being handled my Magento as well and sending improper custom option data results in entire quote getting corrupted)