### PR TITLE
Cart and Minicart don't respect out of stock threshold #627 (SPO-255)

### DIFF
--- a/src/Model/Resolver/SaveCartItem.php
+++ b/src/Model/Resolver/SaveCartItem.php
@@ -324,7 +324,7 @@ class SaveCartItem implements ResolverInterface
             /** @var StockItemConfigurationInterface $stockItemConfiguration */
             $stockItemConfiguration = $this->getStockItemConfiguration->execute($sku, $stockId);
 
-            $qtyWithReservation = $stockItemData[GetStockItemDataInterface::QUANTITY] +
+            $qtyWithReservation = $stockItemData[GetStockItemDataInterface::QTY] +
                 $this->getReservationsQuantity->execute($sku, $stockId);
 
             $qtyLeftInStock = $qtyWithReservation - $stockItemConfiguration->getMinQty();

--- a/src/Model/Resolver/SaveCartItem.php
+++ b/src/Model/Resolver/SaveCartItem.php
@@ -336,8 +336,6 @@ class SaveCartItem implements ResolverInterface
                 throw new GraphQlInputException(new Phrase('The requested quantity is not available'));
             }
         } else {
-            throw new GraphQlInputException(new Phrase('yes'));
-
             $fitsInStock = $qty <= $stockItem->getQty();
             $isInMinMaxSaleRange = $qty >= $stockItem->getMinSaleQty() || $qty <= $stockItem->getMaxSaleQty();
 


### PR DESCRIPTION
This should fix the Minicart/Cart bug with adding more item quantity than BE has in stock.
CR & QA required before merging.

Note: While the ticket describes that PDP item quantity works, it did not work on my local. User is able to add more products than possible (input has default maxSaleQty of 10000).
If this issue is reproducible, PDP quantity input must be limited to maxSaleQty OR simple product quantity.