### PR TITLE
SWPWA-558 - Order view breaks with disabled products

### DIFF
--- a/src/Model/Resolver/ProductResolver.php
+++ b/src/Model/Resolver/ProductResolver.php
@@ -103,7 +103,8 @@ class ProductResolver implements ResolverInterface
                 true,
                 false,
                 false,
-                true
+                true,
+                $productIds
             )
             ->getItems();
 


### PR DESCRIPTION
This fixes issue that in my account orders the order view is not opening if there is disabled product

See also - https://github.com/scandipwa/catalog-graphql/pull/60