### PR TITLE
#1645 Logged user can't complete order,if disabled guest Checkout

### DIFF
--- a/src/Model/Cart/CheckCartCheckoutAllowance.php
+++ b/src/Model/Cart/CheckCartCheckoutAllowance.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/quote-graphql
+ * @link    https://github.com/scandipwa/quote-graphql
+ */
+namespace ScandiPWA\QuoteGraphQl\Model\Cart;
+
+use Magento\Checkout\Helper\Data as CheckoutHelper;
+use Magento\Framework\GraphQl\Exception\GraphQlAuthorizationException;
+use Magento\Quote\Model\Quote;
+use Magento\QuoteGraphQl\Model\Cart\CheckCartCheckoutAllowance as SourceCheckCartCheckoutAllowance;
+
+/**
+ * Class CheckCartCheckoutAllowance
+ * @package ScandiPWA\QuoteGraphQl\Model\Cart
+ */
+class CheckCartCheckoutAllowance extends SourceCheckCartCheckoutAllowance
+{
+    /**
+     * @var CheckoutHelper
+     */
+    protected $checkoutHelper;
+
+    /**
+     * CheckCartCheckoutAllowance constructor.
+     * @param CheckoutHelper $checkoutHelper
+     */
+    public function __construct(CheckoutHelper $checkoutHelper)
+    {
+        $this->checkoutHelper = $checkoutHelper;
+        parent::__construct($checkoutHelper);
+    }
+
+    /**
+     * @param Quote $quote
+     * @throws \Magento\Framework\GraphQl\Exception\GraphQlAuthorizationException
+     */
+    public function execute(Quote $quote): void {
+        if (false == $quote->getCustomerIsGuest()) {
+            return;
+        }
+
+        $isAllowedGuestCheckout = (bool)$this->checkoutHelper->isAllowedGuestCheckout($quote);
+        if (false === $isAllowedGuestCheckout) {
+            throw new GraphQlAuthorizationException(
+                __(
+                    'Guest checkout is not allowed. ' .
+                    'Register a customer account or login with existing one.'
+                )
+            );
+        }
+    }
+}

--- a/src/Model/Quote/Quote.php
+++ b/src/Model/Quote/Quote.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/quote-graphql
+ * @link    https://github.com/scandipwa/quote-graphql
+ */
+namespace ScandiPWA\QuoteGraphQl\Model\Quote;
+
+use Magento\Quote\Model\Quote as SourceQuote;
+
+/**
+ * Class Quote
+ * @package ScandiPWA\QuoteGraphQl\Model\Quote
+ */
+class Quote extends SourceQuote
+{
+    /**
+     * @return $this|Quote
+     */
+    public function beforeSave()
+    {
+        parent::beforeSave();
+        $customerIsGuest = !$this->_customer || $this->getCustomerId() == null;
+        $this->setCustomerIsGuest($customerIsGuest);
+        return $this;
+    }
+}

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <preference for="Magento\Quote\Model\Quote" type="ScandiPWA\QuoteGraphQl\Model\Quote\Quote"/>
+    <preference for="Magento\QuoteGraphQl\Model\Cart\CheckCartCheckoutAllowance" type="ScandiPWA\QuoteGraphQl\Model\Cart\CheckCartCheckoutAllowance"/>
+</config>
+


### PR DESCRIPTION
Original issue [#1645](https://github.com/scandipwa/base-theme/issues/1645)

## Issue requirements:
- Logged user can complete order, when Allow Guest Checkout is disabled.

## In this PR:
Issue was caused due to two issues:
- Quote has variable "customer_is_guest" which is accessed when checking weather checkout is allowed. In Magento there is bug that causes this value to always be "0", to fix this I overwrote Quote module and added an extra setter before save.
- There was a strong check for values "false" & "$quote->getCustomerIsGuest()", but getCustomerIsGuest() returns integer so i replaced "===" with "=="