### PR TITLE
#1514 Data layer add transactin id

### DIFF
--- a/src/Model/Resolver/PlaceOrder.php
+++ b/src/Model/Resolver/PlaceOrder.php
@@ -23,6 +23,7 @@ use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
 use Magento\Quote\Api\CartManagementInterface;
 use Magento\QuoteGraphQl\Model\Cart\GetCartForUser;
 use Magento\Sales\Api\OrderRepositoryInterface;
+use Magento\QuoteGraphQl\Model\Cart\CheckCartCheckoutAllowance;
 use Magento\Sales\Api\Data\TransactionSearchResultInterfaceFactory;
 /**
  * @inheritdoc
@@ -132,6 +133,5 @@ class PlaceOrder implements ResolverInterface
         } catch (\Exception $e) {
             throw new LocalizedException("Unable to capture transaction");
         }
-
     }
 }

--- a/src/etc/schema.graphqls
+++ b/src/etc/schema.graphqls
@@ -260,6 +260,7 @@ type Order {
     base_order_info: BaseOrderInfo
     payment_info: PaymentInfo
     shipping_info: ShippingInfo
+    transaction_id: String
     order_products: [ProductInterface] @resolver(class: "\\ScandiPWA\\QuoteGraphQl\\Model\\Resolver\\ProductResolver")
 }
 


### PR DESCRIPTION
Original issue: [#1514](https://github.com/scandipwa/base-theme/issues/1514)

Requirements:
* Add support for transaction id for GTM purchase event.

In this PR:
* Added new field "transaction_id" for grahQl to get when order is placed.