### PR TITLE
Resolved an issue where the minimum and maximum qty allowed in cart

### DIFF
--- a/src/Model/Resolver/SaveCartItem.php
+++ b/src/Model/Resolver/SaveCartItem.php
@@ -387,10 +387,25 @@ class SaveCartItem implements ResolverInterface
         }
 
         $fitsInStock = $qty <= $stockItem->getQty();
-        $isInMinMaxSaleRange = $qty >= $stockItem->getMinSaleQty() || $qty <= $stockItem->getMaxSaleQty();
 
-        if (!($fitsInStock && $isInMinMaxSaleRange)) {
+        if (!$fitsInStock) {
             throw new GraphQlInputException(new Phrase('Provided quantity exceeds stock limits'));
+        }
+
+        $isMinSaleQuantityCheckFailed = $qty < $stockItem->getMinSaleQty();
+
+        if ($isMinSaleQuantityCheckFailed) {
+            throw new GraphQlInputException(
+                new Phrase('The fewest you may purchase is %1', [$stockItem->getMinSaleQty()])
+            );
+        }
+
+        $isMaxSaleQuantityCheckFailed = $qty > $stockItem->getMaxSaleQty();
+
+        if ($isMaxSaleQuantityCheckFailed) {
+            throw new GraphQlInputException(
+                new Phrase('The requested qty exceeds the maximum qty allowed in shopping cart')
+            );
         }
 
         $stockId = $stockItem->getStockId();


### PR DESCRIPTION
This fixes issue https://github.com/scandipwa/scandipwa/issues/1517

Resolved an issue where the minimum and maximum qty allowed in the cart wasn't working when changing the qty from the cart and added more explanatory error messages.

Basically, it would have also worked perfectly fine if we just changed the logical OR to the AND in the `src/Model/Resolver/SaveCartItem.php:390` (from `$isInMinMaxSaleRange = $qty >= $stockItem->getMinSaleQty() || $qty <= $stockItem->getMaxSaleQty();` to `$isInMinMaxSaleRange = $qty >= $stockItem->getMinSaleQty() && $qty <= $stockItem->getMaxSaleQty();`) but that would have left us with not so great error messages so I decided to add a unique error message for each case.