### PR TITLE
#1877 add ability to pass grouped products qty when add to wishlist

### DIFF
--- a/src/etc/schema.graphqls
+++ b/src/etc/schema.graphqls
@@ -69,6 +69,12 @@ input ExtensionsAttributeInput {
     customizable_options: [CustomizableOptionsInput]
     customizable_options_multi: [CustomizableOptionsInput]
     bundle_options: [BundleOptionInput!]
+    grouped_options: [GroupedOptionInput!]
+}
+
+input GroupedOptionInput {
+    product_id: Int!
+    quantity: Int!
 }
 
 input ConfigurableItemOptionsInput {


### PR DESCRIPTION
Adding support for grouped product quantities in wishlist: https://github.com/scandipwa/scandipwa/issues/1877

Current change is required for additional parameters (i.e. product ids and their quantities) to be passed in GQL request when adding a grouped product to wishlist.

Related PRs: https://github.com/scandipwa/scandipwa/pull/2301 and https://github.com/scandipwa/wishlist-graphql/pull/13

### As discussed with @lianastaskevica: it turned out that the changes @riha112 made under https://github.com/scandipwa/scandipwa/issues/1876 task are supposed to include the same functionality. If PR for #1876, is successfully merged, merging this PR is not required. Please review the changes, and leave comments for me to take into account in the future. The PR itself will be cancelled after that.