### PR TITLE
Quote ID Type Fix

### DIFF
--- a/src/Model/Resolver/SaveCartItem.php
+++ b/src/Model/Resolver/SaveCartItem.php
@@ -304,7 +304,7 @@ class SaveCartItem implements ResolverInterface
         $quoteIdMask = $this->quoteIdMaskFactory->create();
         $this->quoteIdMaskResource->load($quoteIdMask, $guestCardId, 'masked_id');
 
-        return $quoteIdMask->getQuoteId();
+        return $quoteIdMask->getQuoteId() ?? '';
     }
 
     /**


### PR DESCRIPTION
Fixes scandipwa/scandipwa#1794
Fixed getGuestQuoteId issue when quote id is null, but since it's stated that the method returns string, an error was produced to the logs. 