### PR TITLE
#2376 - Fix PR #62 - Added support for image upload for customizable options 

### DIFF
--- a/src/Helper/ImageUpload.php
+++ b/src/Helper/ImageUpload.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/quote-graphql
+ * @link    https://github.com/scandipwa/quote-graphql
+ */
+
+namespace ScandiPWA\QuoteGraphQl\Helper;
+
+use Exception;
+use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\Filesystem;
+use Magento\Quote\Model\Quote\Item\Option;
+use Magento\Quote\Model\Quote\Item\OptionFactory;
+
+class ImageUpload {
+    const QUOTE_MEDIA_PATH = 'custom_options/quote/';
+    const ORDER_MEDIA_PATH = 'custom_options/order/';
+
+    /**
+     * @var OptionFactory
+     */
+    protected $optionFactory;
+
+    /**
+     * @var string
+     */
+    protected $mediaPath;
+
+    /**
+     * ImageUpload constructor.
+     * @param OptionFactory $optionFactory
+     * @param Filesystem $filesystem
+     */
+    public function __construct(
+        OptionFactory $optionFactory,
+        Filesystem $filesystem
+    ) {
+        $this->optionFactory = $optionFactory;
+        $this->mediaPath = $filesystem->getDirectoryRead(DirectoryList::MEDIA)->getAbsolutePath();
+    }
+
+    /**
+     * @param $quote
+     * @param $requestCartItem
+     * @throws Exception
+     */
+    public function processFileUpload($quote, $requestCartItem)
+    {
+        $options = $requestCartItem['product_option']['extension_attributes']['customizable_options'] ?? false;
+
+        if ($options) {
+            $quoteItem = array_slice($quote->getItems(), -1)[0];
+            $existingOptionsIds = $quoteItem->getOptionByCode('option_ids') ?? $this->createOptionIds($quoteItem);
+            $existingOptionsIdsValue = $existingOptionsIds->getValue();
+
+            foreach ($options as $option) {
+                $optionId = $option['option_id'];
+                $optionValue = $option['option_value'];
+                $quoteId = $quote->getId();
+                $productId = $quoteItem->getProductId();
+
+                if (
+                    !in_array($optionId, explode(',', $existingOptionsIdsValue))
+                    && strpos($optionValue, 'base64')
+                ) {
+                    $filename = base64_encode(sprintf(
+                        '%s-%s-%s',
+                        $quoteId,
+                        $productId,
+                        time()
+                    ));
+                    $data = $this->getOptionData($quoteId, $filename);
+
+                    $existingOptionsIds->setValue(sprintf(
+                        '%s%s',
+                        $existingOptionsIdsValue ? $existingOptionsIdsValue . ',' : '',
+                        $optionId
+                    ))->save();
+
+                    $buyRequest = $quoteItem->getOptionByCode('info_buyRequest');
+                    $buyRequestValue = (array) json_decode($buyRequest->getValue());
+                    $buyRequestOptions = (array) $buyRequestValue['options'];
+                    $buyRequestOptions[$optionId] = $data;
+                    $buyRequestValue['options'] = $buyRequestOptions;
+                    $buyRequest->setValue(json_encode($buyRequestValue))->save();
+
+                    $this->optionFactory->create()->setData([
+                        'item_id' => $quoteItem->getId(),
+                        'product_id' => $productId,
+                        'code' => 'option_' . $optionId,
+                        'value' => json_encode($data)
+                    ])->save();
+
+                    $this->createFileAndFolder($quoteId, $optionValue , $filename);
+                }
+            }
+        }
+    }
+
+    /**
+     * @param $quoteId
+     * @param $value
+     * @param $filename
+     */
+    public function createFileAndFolder($quoteId, $value, $filename)
+    {
+        $directory = sprintf(
+            '%s%s%s/_',
+            $this->mediaPath,
+            self::QUOTE_MEDIA_PATH,
+            $quoteId
+        );
+
+        if (!is_dir($directory)) {
+            mkdir($directory, 0777, true);
+        }
+
+        file_put_contents(
+            sprintf('%s/%s', $directory, $filename),
+            base64_decode(substr($value, strpos($value, ',') + 1 ))
+        );
+    }
+
+    /**
+     * Get data for quote_item_options table
+     *
+     * @param $quoteId
+     * @param $filename
+     * @return array
+     */
+    public function getOptionData($quoteId, $filename)
+    {
+        $insidePath = $quoteId . '/_/' . $filename;
+
+        return [
+            'type' => 'application/octet-stream',
+            'title' => $filename,
+            'quote_path' => self::QUOTE_MEDIA_PATH . $insidePath,
+            'order_path' => self::ORDER_MEDIA_PATH . $insidePath,
+            'fullpath' => $this->mediaPath . self::QUOTE_MEDIA_PATH . $insidePath,
+            'secret_key' => $filename
+        ];
+    }
+
+    /**
+     * @param $quoteItem
+     * @return Option
+     * @throws Exception
+     */
+    public function createOptionIds($quoteItem)
+    {
+        return $this->optionFactory->create()->setData([
+            'item_id' => $quoteItem->getId(),
+            'product_id' => $quoteItem->getProductId(),
+            'code' => 'option_ids',
+            'value' => ''
+        ])->save();
+    }
+}

--- a/src/Model/CartItem/DataProvider/CustomizableOptionValue/File.php
+++ b/src/Model/CartItem/DataProvider/CustomizableOptionValue/File.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/quote-graphql
+ * @link    https://github.com/scandipwa/quote-graphql
+ */
+declare(strict_types=1);
+
+namespace ScandiPWA\QuoteGraphQl\Model\CartItem\DataProvider\CustomizableOptionValue;
+
+use Magento\Catalog\Model\Product\Option;
+use Magento\Catalog\Model\Product\Option\Type\Text as TextOptionType;
+use Magento\Quote\Model\Quote\Item as QuoteItem;
+use Magento\Quote\Model\Quote\Item\Option as SelectedOption;
+use Magento\QuoteGraphQl\Model\CartItem\DataProvider\CustomizableOptionValueInterface;
+use Magento\QuoteGraphQl\Model\CartItem\DataProvider\CustomizableOptionValue\PriceUnitLabel;
+
+/**
+ * @inheritdoc
+ */
+class File implements CustomizableOptionValueInterface
+{
+    /**
+     * @var PriceUnitLabel
+     */
+    private $priceUnitLabel;
+
+    /**
+     * @param PriceUnitLabel $priceUnitLabel
+     */
+    public function __construct(
+        PriceUnitLabel $priceUnitLabel
+    ) {
+        $this->priceUnitLabel = $priceUnitLabel;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getData(
+        QuoteItem $cartItem,
+        Option $option,
+        SelectedOption $selectedOption
+    ): array {
+        /** @var TextOptionType $optionTypeRenderer */
+        $optionTypeRenderer = $option->groupFactory($option->getType());
+        $optionTypeRenderer->setOption($option);
+        $priceValueUnits = $this->priceUnitLabel->getData($option->getPriceType());
+
+        $selectedOptionValueData = [
+            'id' => $selectedOption->getId(),
+            'label' => '',
+            'value' => json_decode($selectedOption->getValue())->title,
+            'price' => [
+                'type' => strtoupper($option->getPriceType()),
+                'units' => $priceValueUnits,
+                'value' => $option->getPrice(),
+            ],
+        ];
+
+        return [$selectedOptionValueData];
+    }
+}

--- a/src/Model/Product/Option/Type/File/ValidatorFile.php
+++ b/src/Model/Product/Option/Type/File/ValidatorFile.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/quote-graphql
+ * @link    https://github.com/scandipwa/quote-graphql
+ */
+declare(strict_types=1);
+
+namespace ScandiPWA\QuoteGraphQl\Model\Product\Option\Type\File;
+
+use Magento\Catalog\Model\Product\Option\Type\File\ValidatorFile as OriginalValidatorFile;
+use Magento\Framework\Math\Random;
+
+/**
+ * Validator class. Represents logic for validation file given from product option
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+class ValidatorFile extends OriginalValidatorFile
+{
+    /**
+     * Constructor method
+     *
+     * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
+     * @param \Magento\Framework\Filesystem $filesystem
+     * @param \Magento\Framework\File\Size $fileSize
+     * @param \Magento\Framework\HTTP\Adapter\FileTransferFactory $httpFactory
+     * @param \Magento\Framework\Validator\File\IsImage $isImageValidator
+     * @param Random|null $random
+     * @throws \Magento\Framework\Exception\FileSystemException
+     */
+    public function __construct(
+        \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
+        \Magento\Framework\Filesystem $filesystem,
+        \Magento\Framework\File\Size $fileSize,
+        \Magento\Framework\HTTP\Adapter\FileTransferFactory $httpFactory,
+        \Magento\Framework\Validator\File\IsImage $isImageValidator,
+        Random $random = null
+    ) {
+        parent::__construct($scopeConfig, $filesystem, $fileSize, $httpFactory, $isImageValidator, $random);
+    }
+
+    /**
+     * ScandiPWA uses completely different approach to upload files: we're sending base64-encoded file content in JSON
+     * But standard FileValidator used by Magento expects file in the multipart/form-data request. That's why we're
+     * getting rid of default validation logic.
+     */
+    public function validate($processingParams, $option)
+    {
+        return null;
+    }
+}

--- a/src/Model/Resolver/SaveCartItem.php
+++ b/src/Model/Resolver/SaveCartItem.php
@@ -390,6 +390,8 @@ class SaveCartItem implements ResolverInterface
             $quote->setTotalsCollectedFlag(false)->collectTotals();
             $this->quoteRepository->save($quote);
 
+            // We need file upload logic exactly after new quote has arrived
+            // Otherwise magento gives us quote with empty prices
             $this->imageUpload->processFileUpload($quote, $requestCartItem);
         }
 

--- a/src/Model/Resolver/SaveCartItem.php
+++ b/src/Model/Resolver/SaveCartItem.php
@@ -42,6 +42,7 @@ use Magento\InventoryConfigurationApi\Api\Data\StockItemConfigurationInterface;
 use Magento\InventoryConfigurationApi\Api\GetStockItemConfigurationInterface;
 use Magento\InventoryReservationsApi\Model\GetReservationsQuantityInterface;
 use Magento\InventorySalesApi\Model\GetStockItemDataInterface;
+use ScandiPWA\QuoteGraphQl\Helper\ImageUpload;
 
 /**
  * Class SaveCartItem
@@ -105,6 +106,11 @@ class SaveCartItem implements ResolverInterface
     private $getStockItemConfiguration;
 
     /**
+     * @var ImageUpload
+     */
+    private $imageUpload;
+
+    /**
      * SaveCartItem constructor.
      *
      * @param QuoteIdMaskFactory $quoteIdMaskFactory
@@ -115,6 +121,10 @@ class SaveCartItem implements ResolverInterface
      * @param QuoteIdMask $quoteIdMaskResource
      * @param Configurable $configurableType
      * @param StockStatusRepositoryInterface $stockStatusRepository
+     * @param GetStockItemDataInterface $getStockItemData
+     * @param GetReservationsQuantityInterface $getReservationsQuantity
+     * @param GetStockItemConfigurationInterface $getStockItemConfiguration
+     * @param ImageUpload $imageUpload
      */
     public function __construct(
         QuoteIdMaskFactory $quoteIdMaskFactory,
@@ -127,7 +137,8 @@ class SaveCartItem implements ResolverInterface
         StockStatusRepositoryInterface $stockStatusRepository,
         GetStockItemDataInterface $getStockItemData,
         GetReservationsQuantityInterface $getReservationsQuantity,
-        GetStockItemConfigurationInterface $getStockItemConfiguration
+        GetStockItemConfigurationInterface $getStockItemConfiguration,
+        ImageUpload $imageUpload
     ) {
         $this->quoteIdMaskFactory = $quoteIdMaskFactory;
         $this->quoteRepository = $quoteRepository;
@@ -140,6 +151,7 @@ class SaveCartItem implements ResolverInterface
         $this->getStockItemData = $getStockItemData;
         $this->getReservationsQuantity = $getReservationsQuantity;
         $this->getStockItemConfiguration = $getStockItemConfiguration;
+        $this->imageUpload = $imageUpload;
     }
 
     /**
@@ -358,6 +370,8 @@ class SaveCartItem implements ResolverInterface
             $quote = $this->quoteRepository->getActive($quoteId);
             $quote->setTotalsCollectedFlag(false)->collectTotals();
             $this->quoteRepository->save($quote);
+
+            $this->imageUpload->processFileUpload($quote, $requestCartItem);
         }
 
         return [];

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -28,6 +28,12 @@
             </argument>
         </arguments>
     </type>
+    <type name="Magento\Catalog\Model\Product\Option\Type\File">
+        <arguments>
+            <argument name="validatorInfo" xsi:type="object">Magento\Catalog\Model\Product\Option\Type\File\ValidatorInfo\Proxy</argument>
+            <argument name="validatorFile" xsi:type="object">ScandiPWA\QuoteGraphQl\Model\Product\Option\Type\File\ValidatorFile\Proxy</argument>
+        </arguments>
+    </type>
     <virtualType name="ScandiPWA\Router\Controller\ConfigurableRouter" type="ScandiPWA\Router\Controller\Router">
         <arguments>
             <argument name="ignoredURLs" xsi:type="array">

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -12,5 +12,28 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
     <preference for="Magento\Quote\Model\Quote" type="ScandiPWA\QuoteGraphQl\Model\Quote\Quote"/>
     <preference for="Magento\QuoteGraphQl\Model\Cart\CheckCartCheckoutAllowance" type="ScandiPWA\QuoteGraphQl\Model\Cart\CheckCartCheckoutAllowance"/>
+    <type name="Magento\QuoteGraphQl\Model\CartItem\DataProvider\CustomizableOptionValue\Composite">
+        <arguments>
+            <argument name="customizableOptionValues" xsi:type="array">
+                <item name="field" xsi:type="string">Magento\QuoteGraphQl\Model\CartItem\DataProvider\CustomizableOptionValue\Text</item>
+                <item name="date" xsi:type="string">Magento\QuoteGraphQl\Model\CartItem\DataProvider\CustomizableOptionValue\Text</item>
+                <item name="time" xsi:type="string">Magento\QuoteGraphQl\Model\CartItem\DataProvider\CustomizableOptionValue\Text</item>
+                <item name="date_time" xsi:type="string">Magento\QuoteGraphQl\Model\CartItem\DataProvider\CustomizableOptionValue\Text</item>
+                <item name="area" xsi:type="string">Magento\QuoteGraphQl\Model\CartItem\DataProvider\CustomizableOptionValue\Text</item>
+                <item name="drop_down" xsi:type="string">Magento\QuoteGraphQl\Model\CartItem\DataProvider\CustomizableOptionValue\Dropdown</item>
+                <item name="radio" xsi:type="string">Magento\QuoteGraphQl\Model\CartItem\DataProvider\CustomizableOptionValue\Dropdown</item>
+                <item name="checkbox" xsi:type="string">Magento\QuoteGraphQl\Model\CartItem\DataProvider\CustomizableOptionValue\Multiple</item>
+                <item name="multiple" xsi:type="string">Magento\QuoteGraphQl\Model\CartItem\DataProvider\CustomizableOptionValue\Multiple</item>
+                <item name="file" xsi:type="string">ScandiPWA\QuoteGraphQl\Model\CartItem\DataProvider\CustomizableOptionValue\File</item>
+            </argument>
+        </arguments>
+    </type>
+    <virtualType name="ScandiPWA\Router\Controller\ConfigurableRouter" type="ScandiPWA\Router\Controller\Router">
+        <arguments>
+            <argument name="ignoredURLs" xsi:type="array">
+                <item name="sales" xsi:type="string">^/sales/.*</item>
+            </argument>
+        </arguments>
+    </virtualType>
 </config>
 

--- a/src/etc/schema.graphqls
+++ b/src/etc/schema.graphqls
@@ -80,6 +80,7 @@ input ConfigurableItemOptionsInput {
 input CustomizableOptionsInput {
     option_id: String!
     option_value: String
+    option_filename: String
 }
 
 input DownloadableProductLinksInput {

--- a/src/etc/schema.graphqls
+++ b/src/etc/schema.graphqls
@@ -365,3 +365,14 @@ type AppliedTaxItemRate {
 extend input CartAddressInput {
     vat_id: String
 }
+
+type CustomizableFileOption implements CustomizableOptionInterface {
+    value: CustomizableFileValue
+}
+
+type CustomizableFieldValue {
+    file_extension: String @doc(description: "Option file extensions (If type file).")
+    price: Float
+    price_type: PriceTypeEnum
+    sku: String
+}


### PR DESCRIPTION
This is a copy of PR https://github.com/scandipwa/quote-graphql/pull/62 with a few fixes.
My changes:

- Added missing field `option_filename` to schema
- Magento default `ValidatorFile` was overriden, because we're using another approach to upload files. Standard `ValidatorFile` expects `multipart/form-data`, but ScandiPWA frontend sends file content as base64-encoded string.