### PR TITLE
Fixed customizable product qty changer

### DIFF
--- a/src/Model/Resolver/SaveCartItem.php
+++ b/src/Model/Resolver/SaveCartItem.php
@@ -394,8 +394,11 @@ class SaveCartItem implements ResolverInterface
         if ($itemId) {
             $cartItem = $quote->getItemById($itemId);
             $product = $cartItem->getProduct();
+            $options = $product->getTypeInstance(true)->getOrderOptions($product) ?? [];
 
-            if ($product->getTypeId() === Bundle::TYPE_CODE) {
+            if ($product->getData('has_options') && isset($options['options'])) {
+                $this->updateCartItem->execute($quote, $itemId, $qty, []);
+            } else  if ($product->getTypeId() === Bundle::TYPE_CODE) {
                 $this->updateCartItem->execute($quote, $itemId, $qty, []);
             } else {
                 $this->checkItemQty($cartItem, $qty);


### PR DESCRIPTION
Original issue:
* https://github.com/scandipwa/scandipwa/issues/3269

Problem:
* When product contains customizable options new sku is generated. If we try to update cart item qty directly error will be outputted for non existing product.

In this PR:
* Using Magento native graphql resolver function for updating qty, for customizable products.