### PR TITLE
#3490 - add product with attachment to cart from wishlist

### DIFF
--- a/src/Model/FileSupport/BuyRequest/CustomizableOptionDataProvider.php
+++ b/src/Model/FileSupport/BuyRequest/CustomizableOptionDataProvider.php
@@ -64,6 +64,12 @@ class CustomizableOptionDataProvider implements BuyRequestDataProviderInterface
 
             [$optionType, $optionId, $optionValue] = $optionData;
 
+            // Handle previously uploaded file when add product with 'File' customizable option to wishlist
+            if(strpos($optionValue, "file-") === 0){
+                [$filePrefix, $encodedFileInfo] = \explode('-', $optionValue);
+                $optionValue = json_decode(base64_decode($encodedFileInfo));
+            }
+
             if ($optionType == self::OPTION_TYPE) {
                 $customizableOptionsData[$optionId][] = $optionValue;
             }


### PR DESCRIPTION
**Issue:**
* Fixes https://github.com/scandipwa/scandipwa/issues/3490

**Problem:**
* When user adds wishlist item to cart, all options are being passed as `selected_options` (it's by design). This approach doesn't work well with files, attached when item was added to wishlist.

**Solution**
* When wishlist item has attachment, customizable option value for file is being passed as option value with prefix `file-` + base64 encoded. Backend now handles this case separately and puts decoded customizable option value. It's not possible to handle this without base64 encode, because splitting is done using `/` symbol, which is present in the customizable option value for file attachment.

Frontend PR: https://github.com/scandipwa/scandipwa/pull/3601