### PR TITLE
Remove sales from ignoredUrl

### DIFF
--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -34,13 +34,6 @@
             <argument name="validatorFile" xsi:type="object">ScandiPWA\QuoteGraphQl\Model\Product\Option\Type\File\ValidatorFile\Proxy</argument>
         </arguments>
     </type>
-<!--    <virtualType name="ScandiPWA\Router\Controller\ConfigurableRouter" type="ScandiPWA\Router\Controller\Router">-->
-<!--        <arguments>-->
-<!--            <argument name="ignoredURLs" xsi:type="array">-->
-<!--                <item name="sales" xsi:type="string">^/sales/.*</item>-->
-<!--            </argument>-->
-<!--        </arguments>-->
-<!--    </virtualType>-->
     <preference for="Magento\Quote\Model\Quote\Item\Processor" type="ScandiPWA\QuoteGraphQl\Model\Quote\Item\Processor"/>
     <preference for="Magento\QuoteBundleOptions\Model\Cart\BuyRequest\BundleDataProvider" type="ScandiPWA\QuoteGraphQl\Model\Cart\BuyRequest\BundleDataProvider"/>
     <preference for="Magento\Bundle\Model\Product\Type" type="ScandiPWA\QuoteGraphQl\Model\Bundle\Type"/>

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -34,13 +34,13 @@
             <argument name="validatorFile" xsi:type="object">ScandiPWA\QuoteGraphQl\Model\Product\Option\Type\File\ValidatorFile\Proxy</argument>
         </arguments>
     </type>
-    <virtualType name="ScandiPWA\Router\Controller\ConfigurableRouter" type="ScandiPWA\Router\Controller\Router">
-        <arguments>
-            <argument name="ignoredURLs" xsi:type="array">
-                <item name="sales" xsi:type="string">^/sales/.*</item>
-            </argument>
-        </arguments>
-    </virtualType>
+<!--    <virtualType name="ScandiPWA\Router\Controller\ConfigurableRouter" type="ScandiPWA\Router\Controller\Router">-->
+<!--        <arguments>-->
+<!--            <argument name="ignoredURLs" xsi:type="array">-->
+<!--                <item name="sales" xsi:type="string">^/sales/.*</item>-->
+<!--            </argument>-->
+<!--        </arguments>-->
+<!--    </virtualType>-->
     <preference for="Magento\Quote\Model\Quote\Item\Processor" type="ScandiPWA\QuoteGraphQl\Model\Quote\Item\Processor"/>
     <preference for="Magento\QuoteBundleOptions\Model\Cart\BuyRequest\BundleDataProvider" type="ScandiPWA\QuoteGraphQl\Model\Cart\BuyRequest\BundleDataProvider"/>
     <preference for="Magento\Bundle\Model\Product\Type" type="ScandiPWA\QuoteGraphQl\Model\Bundle\Type"/>


### PR DESCRIPTION
**Related issue(s):**
* Fixes scandipwa/scandipwa#3600

**Problem:**
* all after 'sales' is considered as ignored url and redirected to luma

**In this PR:**
* Sales pattern was added while doing upload file support on products, but from dev who made it is no info on which correct pattern should be used, since '^/sales/.*' is used not only for upload support.
