### PR TITLE
[3552] Magento graphql support integration for cart

### DIFF
--- a/src/Model/Resolver/Cart/Cart.php
+++ b/src/Model/Resolver/Cart/Cart.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/quote-graphql
+ * @link https://github.com/scandipwa/quote-graphql
+ */
+
+declare(strict_types=1);
+
+namespace ScandiPWA\QuoteGraphQl\Model\Resolver\Cart;
+
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Exception\GraphQlInputException;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\Quote\Api\CartManagementInterface;
+use Magento\Quote\Api\GuestCartRepositoryInterface;
+use Magento\QuoteGraphQl\Model\Cart\GetCartForUser;
+use Magento\QuoteGraphQl\Model\Resolver\Cart as SourceCart;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Webapi\Controller\Rest\ParamOverriderCustomerId;
+use Magento\Quote\Model\QuoteIdToMaskedQuoteIdInterface;
+
+/**
+ * @inheritdoc
+ */
+class Cart extends SourceCart
+{
+    /**
+     * @var ParamOverriderCustomerId
+     */
+    public $overriderCustomerId;
+
+    /**
+     * @var CartManagementInterface
+     */
+    public $quoteManagement;
+
+    /**
+     * @var QuoteIdToMaskedQuoteIdInterface
+     */
+    public $quoteIdToMaskedQuoteId;
+
+    /**
+     * CartResolver constructor.
+     */
+    public function __construct(
+        ParamOverriderCustomerId $overriderCustomerId,
+        CartManagementInterface $quoteManagement,
+        GetCartForUser $getCartForUser,
+        QuoteIdToMaskedQuoteIdInterface $quoteIdToMaskedQuoteId
+    ) {
+        $this->quoteManagement = $quoteManagement;
+        $this->overriderCustomerId = $overriderCustomerId;
+        $this->quoteIdToMaskedQuoteId = $quoteIdToMaskedQuoteId;
+        parent::__construct($getCartForUser);
+    }
+
+    /**
+     * @inheirtDoc
+     */
+    public function resolve(Field $field, $context, ResolveInfo $info, array $value = null, array $args = null)
+    {
+        if (!isset($args['cart_id'])) {
+            throw new GraphQlInputException(__('Required parameter "cart_id" is missing'));
+        }
+
+        if (empty($args['cart_id'])) {
+            $id = $this->getCartForLoggedInUser()->getId();
+            $args['cart_id'] = $this->quoteIdToMaskedQuoteId->execute((int)$id);
+        }
+
+        return parent::resolve($field, $context, $info, $value, $args);
+    }
+
+    /**
+     * @return \Magento\Quote\Api\Data\CartInterface
+     */
+    private function getCartForLoggedInUser()
+    {
+        try {
+            return $this->quoteManagement->getCartForCustomer(
+                $this->overriderCustomerId->getOverriddenValue()
+            );
+        } catch (NoSuchEntityException $e) {
+            throw new \UnexpectedValueException(__("Unable to retrieve cart. guestCartId is missing or you are not logged in"), 13, $e);
+        }
+    }
+}

--- a/src/Model/Resolver/Cart/CartItemStatus.php
+++ b/src/Model/Resolver/Cart/CartItemStatus.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/quote-graphql
+ * @link https://github.com/scandipwa/quote-graphql
+ */
+
+declare(strict_types=1);
+
+namespace ScandiPWA\QuoteGraphQl\Model\Resolver\Cart;
+
+use Magento\CatalogInventory\Helper\Data;
+use Magento\CatalogInventory\Model\Stock;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\Quote\Model\Quote\Item;
+use Magento\CatalogInventory\Api\StockRegistryInterface;
+
+/**
+ * Resolves cart items status - out of stock, incorrect qty, ok
+ */
+class CartItemStatus implements ResolverInterface
+{
+    public const ERR_QRY = 'ERR_QTY';
+    public const MSG_OK = 'STATUS_OK';
+
+    /**
+     * @var StockRegistryInterface
+     */
+    public $stockRegistry;
+
+    /**
+     * @param StockRegistryInterface $stockRegistry
+     */
+    public function __construct(StockRegistryInterface $stockRegistry)
+    {
+        $this->stockRegistry = $stockRegistry;
+    }
+
+    public function resolve(Field $field, $context, ResolveInfo $info, array $value = null, array $args = null)
+    {
+        if (!isset($value['model'])) {
+            throw new LocalizedException(__('"model" value should be specified'));
+        }
+
+        /** @var Item $cartItem */
+        $cartItem = $value['model'];
+
+        $product = $cartItem->getProduct();
+        /* @var \Magento\CatalogInventory\Api\Data\StockStatusInterface $stockStatus */
+        $stockStatus = $this->stockRegistry->getStockStatus($product->getId(), $product->getStore()->getWebsiteId());
+
+        /* @var \Magento\CatalogInventory\Api\Data\StockStatusInterface $parentStockStatus */
+        $parentStockStatus = false;
+
+        /**
+         * Check if product in stock. For composite products check base (parent) item stock status
+         */
+        if ($cartItem->getParentItem()) {
+            $product = $cartItem->getParentItem()->getProduct();
+            $parentStockStatus = $this->stockRegistry->getStockStatus(
+                $product->getId(),
+                $product->getStore()->getWebsiteId()
+            );
+        }
+
+        if ($stockStatus) {
+            if ($stockStatus->getStockStatus() === Stock::STOCK_OUT_OF_STOCK
+                || $parentStockStatus && $parentStockStatus->getStockStatus() == Stock::STOCK_OUT_OF_STOCK
+            ) {
+                $hasError = $cartItem->getStockStateResult()
+                    ? $cartItem->getStockStateResult()->getHasError() : false;
+
+                if (!$hasError) {
+                    return Stock::STOCK_OUT_OF_STOCK;
+                } else {
+                    return self::ERR_QRY;
+                }
+            }
+        } else {
+            return Stock::STOCK_OUT_OF_STOCK;
+        }
+
+        return self::MSG_OK;
+    }
+}

--- a/src/Model/Resolver/Cart/CartItems.php
+++ b/src/Model/Resolver/Cart/CartItems.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/quote-graphql
+ * @link https://github.com/scandipwa/quote-graphql
+ */
+
+declare(strict_types=1);
+
+namespace ScandiPWA\QuoteGraphQl\Model\Resolver\Cart;
+
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Query\Uid;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\Quote\Model\Quote\Item as QuoteItem;
+use Magento\QuoteGraphQl\Model\Cart\GetCartProducts;
+use Magento\QuoteGraphQl\Model\Resolver\CartItems as SourceCartItems;
+use Magento\Catalog\Helper\Image;
+
+class CartItems extends SourceCartItems
+{
+    public const THUMBNAIL = 'thumbnail';
+
+    /**
+     * @var Images
+     */
+    protected $imageHelper;
+
+    /**
+     * @param GetCartProducts $getCartProducts
+     * @param Uid $uidEncoder
+     * @param Image $imageHelper
+     */
+    public function __construct(
+        GetCartProducts $getCartProducts,
+        Uid $uidEncoder,
+        Image $imageHelper
+    ) {
+        $this->imageHelper = $imageHelper;
+        parent::__construct($getCartProducts, $uidEncoder);
+    }
+
+    /**
+     * @param Field $field
+     * @param $context
+     * @param ResolveInfo $info
+     * @param array|null $value
+     * @param array|null $args
+     * @return array|\Magento\Framework\GraphQl\Query\Resolver\Value|mixed
+     * @throws \Exception
+     */
+    public function resolve(Field $field, $context, ResolveInfo $info, array $value = null, array $args = null)
+    {
+        $itemsData = parent::resolve($field, $context, $info, $value, $args);
+
+        if (!empty($itemsData)) {
+            foreach ($itemsData as &$item) {
+                $product = $item['model']->getProduct();
+                $path = $product->getData(self::THUMBNAIL);
+                $item['product'][self::THUMBNAIL] = [
+                    'url' => $this->getImageUrl(
+                        self::THUMBNAIL,
+                        $path,
+                        $product
+                    )
+                ];
+            }
+        }
+
+        return $itemsData;
+    }
+
+    /**
+     * @param string $imageType
+     * @param string|null $imagePath
+     * @param $product
+     * @return string
+     */
+    protected function getImageUrl(
+        string $imageType,
+        ?string $imagePath,
+        $product
+    ): string {
+        if (!isset($imagePath)) {
+            return $this->imageHelper->getDefaultPlaceholderUrl($imageType);
+        }
+
+        $imageId = sprintf('scandipwa_%s', $imageType);
+
+        $image = $this->imageHelper
+            ->init(
+                $product,
+                $imageId,
+                ['type' => $imageType]
+            )
+            ->constrainOnly(true)
+            ->keepAspectRatio(true)
+            ->keepTransparency(true)
+            ->keepFrame(false);
+
+        return $image->getUrl();
+    }
+}

--- a/src/Model/Resolver/Cart/CartPrices.php
+++ b/src/Model/Resolver/Cart/CartPrices.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/quote-graphql
+ * @link https://github.com/scandipwa/quote-graphql
+ */
+
+
+namespace ScandiPWA\QuoteGraphQl\Model\Resolver\Cart;
+
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\Quote\Model\Quote;
+use Magento\Quote\Model\Quote\Address\Total;
+use Magento\Quote\Model\Quote\TotalsCollector;
+use Magento\QuoteGraphQl\Model\Resolver\CartPrices as SourceCartPrices;
+
+/**
+ * @inheritdoc
+ */
+class CartPrices extends SourceCartPrices
+{
+    /**
+     * @var TotalsCollector
+     */
+    public $totalsCollector;
+
+    /**
+     * @param TotalsCollector $totalsCollector
+     */
+    public function __construct(TotalsCollector $totalsCollector)
+    {
+        parent::__construct($totalsCollector);
+        $this->totalsCollector = $totalsCollector;
+    }
+
+    public function resolve(Field $field, $context, ResolveInfo $info, array $value = null, array $args = null)
+    {
+        $data = parent::resolve($field, $context, $info, $value, $args);
+
+        /** @var Quote $quote */
+        $quote = $value['model'];
+        $quote->setCartFixedRules([]);
+        $cartTotals = $this->totalsCollector->collectQuoteTotals($quote);
+        $currency = $quote->getQuoteCurrencyCode();
+
+        $data['applied_taxes'] = $this->getAppliedTaxes($cartTotals, $currency);
+        return $data;
+    }
+
+    /**
+     * Returns taxes applied to the current quote
+     *
+     * @param Total $total
+     * @param string $currency
+     * @return array
+     */
+    private function getAppliedTaxes(Total $total, string $currency): array
+    {
+        $appliedTaxesData = [];
+        $appliedTaxes = $total->getAppliedTaxes();
+
+        if (empty($appliedTaxes)) {
+            return $appliedTaxesData;
+        }
+
+        foreach ($appliedTaxes as $appliedTax) {
+            $title = "";
+            if (!empty($appliedTax['rates'])) {
+                $title = $appliedTax['rates'][0]['title'];
+            }
+
+            $appliedTaxesData[] = [
+                'label' => $appliedTax['id'],
+                'title' => $title,
+                'percent' => $appliedTax['percent'],
+                'amount' => ['value' => $appliedTax['amount'], 'currency' => $currency]
+            ];
+        }
+
+        return $appliedTaxesData;
+    }
+}

--- a/src/Model/Resolver/Cart/SelectedShippingMethod.php
+++ b/src/Model/Resolver/Cart/SelectedShippingMethod.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ * @package scandipwa/quote-graphql
+ * @link https://github.com/scandipwa/quote-graphql
+ */
+
+declare(strict_types=1);
+
+namespace ScandiPWA\QuoteGraphQl\Model\Resolver\Cart;
+
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\QuoteGraphQl\Model\Resolver\ShippingAddress\SelectedShippingMethod as SourceSelectedShippingMethod;
+use Magento\Quote\Model\Quote\Address;
+
+/**
+ * @inheritdoc
+ */
+class SelectedShippingMethod extends SourceSelectedShippingMethod
+{
+    /**
+     * @inheritdoc
+     */
+    public function resolve(Field $field, $context, ResolveInfo $info, array $value = null, array $args = null)
+    {
+        $data = parent::resolve($field, $context, $info, $value, $args);
+
+        /** @var Address $address */
+        $address = $value['model'];
+
+        $data['amount_with_tax'] = [
+            'value' => $address->getShippingInclTax(),
+            'currency' => $address->getQuote()->getQuoteCurrencyCode(),
+        ];
+
+        return $data;
+    }
+}

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -39,5 +39,9 @@
     <preference for="Magento\Bundle\Model\Product\Type" type="ScandiPWA\QuoteGraphQl\Model\Bundle\Type"/>
     <preference for="Magento\Catalog\Model\Product\Option\Type\File" type="ScandiPWA\QuoteGraphQl\Model\FileSupport\Option\File"/>
     <preference for="Magento\Quote\Model\Cart\BuyRequest\CustomizableOptionDataProvider" type="ScandiPWA\QuoteGraphQl\Model\FileSupport\BuyRequest\CustomizableOptionDataProvider"/>
+    <preference for="Magento\QuoteGraphQl\Model\Resolver\ShippingAddress\SelectedShippingMethod" type="ScandiPWA\QuoteGraphQl\Model\Resolver\Cart\SelectedShippingMethod"/>
+    <preference for="Magento\QuoteGraphQl\Model\Resolver\CartPrices" type="ScandiPWA\QuoteGraphQl\Model\Resolver\Cart\CartPrices"/>
+    <preference for="Magento\QuoteGraphQl\Model\Resolver\Cart" type="ScandiPWA\QuoteGraphQl\Model\Resolver\Cart\Cart"/>
+    <preference for="Magento\QuoteGraphQl\Model\Resolver\CartItems" type="ScandiPWA\QuoteGraphQl\Model\Resolver\Cart\CartItems"/>
 </config>
 

--- a/src/etc/schema.graphqls
+++ b/src/etc/schema.graphqls
@@ -416,3 +416,18 @@ input AddressExtensionAttributes {
     attribute_code: String
     value: String
 }
+
+type SelectedShippingMethod {
+    amount_with_tax: Money!
+}
+
+type CartTaxItem {
+    amount: Money!
+    percent: Float
+    label: String!
+    title: String!
+}
+
+interface CartItemInterface {
+    status: String! @resolver(class: "\\ScandiPWA\\QuoteGraphQl\\Model\\Resolver\\Cart\\CartItemStatus")
+}


### PR DESCRIPTION
**Original issue:** https://github.com/scandipwa/scandipwa/issues/3552

**In this PR:**
* Added support for Magentos native graphql request `cart` to work with authorized customers
* Added BE support for cart item stock status & qty validation
* Added support for Magentos native graphql item `CartTaxItem`  - percent & title
* Added support for Magentos native graphql item `SelectedShippingMethod` - amount with tax