### PR TITLE
created a parameter for checking the cartItem

### DIFF
--- a/src/Model/Resolver/GetCartForCustomer.php
+++ b/src/Model/Resolver/GetCartForCustomer.php
@@ -240,7 +240,8 @@ class GetCartForCustomer extends CartResolver
             $this->productsData = $this->productPostProcessor->process(
                 $products,
                 'items/product',
-                $adjustedInfo
+                $adjustedInfo,
+                ['isCartProduct'=> true]
             );
 
             foreach ($items as $item) {


### PR DESCRIPTION
**Related issue(s):**
* Fixes scandipwa/scandipwa#4589

**Problem:**
* The configurable attribute was shown in the widgets even if they were disabled from the admin 

**In this PR:**
* Filtering the attributes if it is PLP or PDP scandipwa/performance#29   and also created a new parameter in `quote-graphql` module and passing it for checking if the product is cartItem or not for showing all attributes there
