### PR TITLE
Update Quote.php

### DIFF
--- a/src/Model/Quote/Quote.php
+++ b/src/Model/Quote/Quote.php
@@ -63,6 +63,6 @@ class Quote extends SourceQuote
         $productId = $product->getId();
         $product = clone $this->productRepository->getById($productId, false, $this->getStore()->getId());
 
-        parent::addProduct($product, $request, $processMode);
+        return parent::addProduct($product, $request, $processMode);
     }
 }


### PR DESCRIPTION
### Fixes exception thrown by missing returned result from addProduct call.

Returned result is used by `vendor/magento/module-quote/Model/Quote.php` (see [here](https://github.com/magento/magento2/blob/2.4.7-p1/app/code/Magento/Quote/Model/Quote.php#L1806-L1814)).

Without it, an exception is thrown when running certain operations (for example, `mergeCarts` GraphQL mutation):

> Call to a member function getParentItem() on null
