### PR TITLE
Fix:empty quote items

### DIFF
--- a/src/Model/Resolver/CartItems.php
+++ b/src/Model/Resolver/CartItems.php
@@ -179,7 +179,7 @@ class CartItems extends SourceCartItems
      */
     public function getCartProductsData(Quote $cart, ResolveInfo $info): array
     {
-        $cartItems = $cart->getItems();
+        $cartItems = $cart->getAllVisibleItems();
         $products = $this->getCartProducts($cartItems);
         $productsData = [];
 


### PR DESCRIPTION
### Getting quote item failed after placing order with the quote.

https://github.com/scandipwa/quote-graphql/tree/3.1.0/src/Model/Resolver/CartItems.php#L182 does not have any data when trying to fetch quote cart items that has already been used, therefore there is no way to access `getProducts` here https://github.com/scandipwa/quote-graphql/tree/3.1.0/src/Model/Resolver/CartItems.php#L243 probably because corresponding `setItems` never happened for that instance,`getAllVisibleItems()` loads and returns the correct items.